### PR TITLE
Need declarative alignment of OCP version from Koffer:VERSION in Konductor image pull

### DIFF
--- a/templates/pod/cloudctl.yml.j2
+++ b/templates/pod/cloudctl.yml.j2
@@ -97,10 +97,10 @@ spec:
     - name: BUILDAH_ISOLATION
       value: chroot
     - name: varVerOpenshift
-      value: 4.5.0-rc.5
+      value: {{ lookup('env', 'varVerOpenshift') }}
     - name: versOCP
-      value: 4.5.0-rc.5
-    image: "docker.io/codesparta/konductor:{{ lookup('env', 'varVerOpenshift') }}"
+      value: {{ lookup('env', 'varVerOpenshift') }}
+    image: docker.io/codesparta/konductor:{{ lookup('env', 'varVerOpenshift') }}
     name: one
     resources: {}
     securityContext:

--- a/templates/pod/cloudctl.yml.j2
+++ b/templates/pod/cloudctl.yml.j2
@@ -100,7 +100,7 @@ spec:
       value: 4.5.0-rc.5
     - name: versOCP
       value: 4.5.0-rc.5
-    image: docker.io/codesparta/konductor:4.5.6
+    image: "docker.io/codesparta/konductor:{{ lookup('env', 'varVerOpenshift') }}"
     name: one
     resources: {}
     securityContext:

--- a/vars/images.yml
+++ b/vars/images.yml
@@ -2,7 +2,7 @@
 images_cloudctl:
   - uri: "docker.io/codesparta"
     name: konductor
-    tag: 4.5.6
+    tag: "{{ lookup('env', 'varVerOpenshift') }}"
     path: "{{ dir_deploy }}/images"
   - uri: "k8s.gcr.io"
     name: pause


### PR DESCRIPTION
Aligns Konductor version with koffer version for OCP version allignment in images.yml var file & cloudctl.yml pod jinja template